### PR TITLE
Removing unnecessary mutex

### DIFF
--- a/polars-explorer/TASKS.MD
+++ b/polars-explorer/TASKS.MD
@@ -1,0 +1,4 @@
+Tracking what I have done for each commit in this file might be a better idea?
+
+- [ ] 
+    1. Removing lower-level Mutex

--- a/polars-explorer/src-tauri/src/Channels.rs
+++ b/polars-explorer/src-tauri/src/Channels.rs
@@ -1,4 +1,4 @@
-use crate::Payload::{DataFrameInfo, DataInfo, DataJSON, PageInfo};
+use crate::Payload::{DataInfo, DataJSON, PageInfo};
 use tauri::ipc::Channel;
 
 pub type DataChannel = Channel<DataJSON>;

--- a/polars-explorer/src-tauri/src/FrameViewManager.rs
+++ b/polars-explorer/src-tauri/src/FrameViewManager.rs
@@ -1,14 +1,13 @@
 use crate::FrameView::FrameView;
 use crate::State::Key;
+use polars::prelude::LazyFrame;
 use std::collections::HashMap;
 use std::sync::atomic::Ordering;
-use std::sync::Mutex;
-use polars::prelude::LazyFrame;
 // Each LoadedFrame keeps a FrameViewManager
 // Which is responsible for handling FrameViews
 
 pub(crate) struct FrameViewManager {
-    pub(crate) view_map: Mutex<HashMap<usize, FrameView>>,
+    pub(crate) view_map: HashMap<usize, FrameView>,
     pub(crate) next_key: Key,
 }
 
@@ -23,7 +22,7 @@ impl FrameViewManager {
         // Add a FrameView to the manager
         // return the key for the loaded view
         let key = &self.next_key.fetch_add(1, Ordering::Relaxed);
-        &self.view_map.lock().unwrap().insert(*key, frame_view);
+        &self.view_map.insert(*key, frame_view);
         *key
     }
 
@@ -32,7 +31,7 @@ impl FrameViewManager {
     pub(crate) fn add_lazyframe(&mut self, frame: LazyFrame, name: String, page_size: usize) -> usize {
         let key = &self.next_key.fetch_add(1, Ordering::Relaxed);
         let view = FrameView::new(*key, name, frame, page_size);
-        &self.view_map.lock().unwrap().insert(*key, view);
+        &self.view_map.insert(*key, view);
         *key
     }
 }

--- a/polars-explorer/src-tauri/src/LoadedFrame.rs
+++ b/polars-explorer/src-tauri/src/LoadedFrame.rs
@@ -1,18 +1,15 @@
 use crate::FrameView::FrameView;
 use crate::FrameViewManager::FrameViewManager;
-use crate::Payload::{DataFrameInfo, PageInfo, ViewResponse};
-use crate::LazyFrame::get_rows;
+use crate::Payload::DataFrameInfo;
 use crate::State::LoadedFrameManager;
-use polars::prelude::{IdxSize, LazyFrame};
+use polars::prelude::LazyFrame;
 use std::sync::atomic::Ordering;
-use std::sync::Mutex;
-use tauri::CursorIcon::Default;
 use tauri::State;
 
 pub struct LoadedFrame {
     // Keep the lazyframe, as well as certain cached results
     pub(crate) base: LazyFrame,
-    pub(crate) view_manager: Mutex<FrameViewManager>,
+    pub(crate) view_manager: FrameViewManager,
     pub(crate) frameInfo: DataFrameInfo,
 }
 
@@ -25,17 +22,15 @@ impl LoadedFrame {
             key: frame_key,
             name: name.clone(),
         };
-        let loaded_frame = LoadedFrame {
+        let mut loaded_frame = LoadedFrame {
             base: base.clone(),
-            view_manager: Mutex::new(FrameViewManager::new()),
+            view_manager: FrameViewManager::new(),
             frameInfo,
         };
         // Initialize the loadedframe with a base view
         // The base view will always have a key of 0
         let _ = loaded_frame
             .view_manager
-            .lock()
-            .unwrap()
             .add(FrameView::base(name, base));
         // Insert the LoadedFrame into the managed state
         state
@@ -45,36 +40,4 @@ impl LoadedFrame {
             .insert(frame_key, loaded_frame);
         frame_key
     }
-
-    // pub fn get_view_guard(&self, view_key: usize) {
-    //     self.views
-    //         .lock()
-    //         .unwrap()
-    //
-    // }
-    // TODO: Move the query logic to frameview
-    // Or maybe not? Maybe better put it into the LoadedFrameManager
-    // Query a page should not gen
-
-    // pub fn query_page(
-    //     self: &Self,
-    //     page: usize,
-    //     pageSize: usize,
-    // ) -> PagedResponse {
-    //     // Implement paginated query on the backend
-    //     // LazyFrame.slice offers in-built support for range validation
-    //     // https://docs.pola.rs/api/rust/dev/polars/prelude/struct.LazyFrame.html#method.slice
-    //     let df = self.frame.clone()
-    //         .slice((page * pageSize) as i64, pageSize as IdxSize)
-    //         .collect()
-    //         .unwrap();
-    //     let response = serde_json::to_value(&df).unwrap();
-    //     let total_page = (self.info.length as f64 / pageSize as f64).ceil() as usize;
-    //     let pageInfo = PageInfo {
-    //         pageSize,
-    //         currentPage: page,
-    //         totalPage: total_page,
-    //     };
-    //     PagedResponse { response, pageInfo }
-    // }
 }

--- a/polars-explorer/src-tauri/src/Query.rs
+++ b/polars-explorer/src-tauri/src/Query.rs
@@ -2,7 +2,6 @@
 // It should be a serialized Array in JSON format
 
 use polars::prelude::{col, Expr};
-use serde::Deserialize;
 pub type JSONArray = String;
 
 

--- a/polars-explorer/src-tauri/src/lib.rs
+++ b/polars-explorer/src-tauri/src/lib.rs
@@ -21,7 +21,7 @@ pub fn run() {
             Commands::open_csv,
             Commands::turn_page,
             Commands::switch_view,
-            Commands::select_column
+            Commands::select_columns
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/polars-explorer/src-tauri/test-csv-generator/src/main.rs
+++ b/polars-explorer/src-tauri/test-csv-generator/src/main.rs
@@ -1,11 +1,11 @@
+use fake::{Dummy, Fake, Faker};
+use rand::seq::SliceRandom;
+use rand::{random, Rng};
+use serde::Serialize;
 use std::fmt::Display;
 use std::fs::File;
 use std::io::{BufWriter, Write};
-use rand::{random, Rng};
-use rand::seq::{IteratorRandom, SliceRandom};
-use fake::{Dummy, Fake, Faker};
 use struct_iterable::Iterable;
-use serde::Serialize;
 
 #[derive(Debug, Dummy, Iterable, Serialize)]
 pub struct AllBaseTypes {
@@ -50,7 +50,6 @@ impl AllBaseTypes {
                                         sep: &str)
     {
         let mut vals = self.to_values();
-        let length = vals.len();
         vals.shuffle(&mut rand::thread_rng());
         write_line(writer, vals, sep);
     }


### PR DESCRIPTION
I was under a false impression regarding how mutex and interior mutability pattern work in Rust: in fact, it looks like all the structures starting from LoadedFrame will be protected by the lock over the LoadedFrame map, so there's no need for extra mutex.